### PR TITLE
Melhora validação de CPF/CNPJ e fluxo no painel de projetos

### DIFF
--- a/apps/web/src/components/panels/ProjetosPanel.tsx
+++ b/apps/web/src/components/panels/ProjetosPanel.tsx
@@ -6,8 +6,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useApp, type Projeto } from '../../pages/AppShell'; // Importa Projeto do AppShell types
 import apiClient from '../../services/api';
-import { Plus, Users, Loader2, Search, Filter, Pencil, Trash2, PlusCircle, FileText, Layers, MapPin } from 'lucide-react';
+import { Plus, Users, Loader2, Pencil, Trash2, PlusCircle } from 'lucide-react';
 import { cn } from '../../lib/utils'; // Função utilitária para classes CSS condicionais (tailwindcss)
+import { toast } from 'sonner';
+import { formatCPF, isValidCpfCnpj } from '../../lib/format-utils';
 
 interface ProjectCardProps {
     projeto: Projeto;
@@ -85,17 +87,15 @@ export default function ProjetosPanel() {
     const { 
         projetos, setProjetos, // Estado para a lista de projetos
         projetoAtual, setProjetoAtual, // Projeto atualmente selecionado
-        activeTool, setActiveTool, // Para gerenciar ferramentas do mapa
-        panel, setPanel, // Para controlar o painel ativo na sidebar
+        setActiveTool, // Para gerenciar ferramentas do mapa
+        setPanel, // Para controlar o painel ativo na sidebar
         setMapZoomTo,
-        refreshUser, // Para recarregar dados do usuário se necessário
         role, // Role do usuário (topografo, etc.)
         clearSelection // Limpa a seleção do mapa quando muda de projeto
     } = useApp();
 
     const [loadingProjects, setLoadingProjects] = useState(true);
     const [creatingProject, setCreatingProject] = useState(false);
-    const [editingProject, setEditingProject] = useState<Projeto | null>(null);
     const [deletingProjectId, setDeletingProjectId] = useState<number | null>(null);
 
     // Carregar projetos ao montar o componente
@@ -129,7 +129,7 @@ export default function ProjetosPanel() {
         clearSelection(); // Limpa seleção de lotes/vértices no mapa
         // Opcional: Mudar o painel para o de lotes desse projeto
         // setPanel('lotes');
-    }, [setProjetoAtual, setActiveTool, setMapZoomTo, clearSelection, setPanel]);
+    }, [setProjetoAtual, setActiveTool, setMapZoomTo, clearSelection]);
 
     // Handler para criar um novo projeto
     const handleCreateProject = async (newProjectData: Omit<Projeto, 'id' | 'statusProjeto' | 'dataCriacao' | 'dataUltimaAtividade' | 'responsavelTopografoId' | 'lotes'>) => {
@@ -148,7 +148,7 @@ export default function ProjetosPanel() {
             if (res.data) {
                 // Atualiza a lista de projetos localmente com o novo projeto
                 setProjetos(prev => [...prev, res.data as Projeto]);
-                toast.sonner.success('Projeto criado com sucesso!');
+                toast.success('Projeto criado com sucesso!');
                 return true; // Indica sucesso
             } else {
                 throw new Error(res.error || 'Falha ao criar projeto');
@@ -164,14 +164,12 @@ export default function ProjetosPanel() {
 
     // Handler para editar um projeto
     const handleEditProject = async (projectId: number, updatedData: Partial<Omit<Projeto, 'id' | 'statusProjeto' | 'dataCriacao' | 'dataUltimaAtividade' | 'responsavelTopografoId' | 'lotes'>>) => {
-        setEditingProject({ ...editingProject!, ...updatedData }); // Atualiza estado local para re-renderizar o form
         try {
             const res = await apiClient.updateProject(projectId, updatedData);
             if (res.data) {
                 // Atualiza a lista de projetos localmente
                 setProjetos(prev => prev.map(p => p.id === projectId ? res.data as Projeto : p));
                 toast.success('Projeto atualizado com sucesso!');
-                setEditingProject(null); // Fecha o modal de edição
                 return true;
             } else {
                 throw new Error(res.error || 'Falha ao atualizar projeto');
@@ -248,14 +246,22 @@ export default function ProjetosPanel() {
         const [formData, setFormData] = useState(project || {
             nomeProjeto: '', nomeCliente: '', cpfCnpjCliente: '', municipio: '', uf: '', statusProjeto: 'Rascunho', descricao: ''
         });
+        const [validationError, setValidationError] = useState('');
         const [saving, setSaving] = useState(false);
 
         const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
             const { name, value } = e.target;
-            setFormData(prev => ({ ...prev, [name]: value }));
+            const nextValue = name === 'cpfCnpjCliente' ? formatCPF(value) : value;
+            setFormData(prev => ({ ...prev, [name]: nextValue }));
+            if (validationError) setValidationError('');
         };
 
         const handleSubmit = async () => {
+            if (formData.cpfCnpjCliente && !isValidCpfCnpj(formData.cpfCnpjCliente)) {
+                setValidationError('CPF/CNPJ inválido. Revise antes de salvar.');
+                return;
+            }
+
             setSaving(true);
             const success = await onSave(formData as any);
             setSaving(false);
@@ -280,6 +286,7 @@ export default function ProjetosPanel() {
 
                         <label>CPF/CNPJ do Cliente</label>
                         <input type="text" name="cpfCnpjCliente" value={formData.cpfCnpjCliente || ''} onChange={handleChange} />
+                        {validationError && <small className="text-red-600">{validationError}</small>}
 
                         <label>Município</label>
                         <input type="text" name="municipio" value={formData.municipio || ''} onChange={handleChange} />
@@ -354,9 +361,8 @@ export default function ProjetosPanel() {
                                 }
                             }}
                             onAddLote={() => {
-                                // Lógica para adicionar lote a este projeto
-                                // Poderia abrir o painel de lotes ou navegar para a tela de lotes
-                                alert('Funcionalidade Adicionar Lote a Projeto ainda não implementada.');
+                                handleSelectProject(p);
+                                setPanel('lotes');
                             }}
                         />
                     ))}

--- a/apps/web/src/lib/__tests__/format-utils.test.ts
+++ b/apps/web/src/lib/__tests__/format-utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { formatCPF, isValidCpfCnpj } from '../format-utils';
+
+describe('format-utils', () => {
+  it('formata CPF', () => {
+    expect(formatCPF('12345678901')).toBe('123.456.789-01');
+  });
+
+  it('formata CNPJ', () => {
+    expect(formatCPF('12345678000195')).toBe('12.345.678/0001-95');
+  });
+
+  it('valida CPF e CNPJ', () => {
+    expect(isValidCpfCnpj('529.982.247-25')).toBe(true);
+    expect(isValidCpfCnpj('04.252.011/0001-10')).toBe(true);
+    expect(isValidCpfCnpj('111.111.111-11')).toBe(false);
+    expect(isValidCpfCnpj('00.000.000/0000-00')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/format-utils.ts
+++ b/apps/web/src/lib/format-utils.ts
@@ -12,7 +12,55 @@ export function formatCPF(value: string): string {
             .replace(/(\d{3})(\d{1,2})/, '$1-$2')
             .replace(/(-\d{2})\d+?$/, '$1');
     }
-    return value;
+
+    return numbers
+        .slice(0, 14)
+        .replace(/(\d{2})(\d)/, '$1.$2')
+        .replace(/(\d{3})(\d)/, '$1.$2')
+        .replace(/(\d{3})(\d)/, '$1/$2')
+        .replace(/(\d{4})(\d{1,2})$/, '$1-$2');
+}
+
+export function isValidCpfCnpj(value: string): boolean {
+    const digits = value.replace(/\D/g, '');
+    if (digits.length === 11) return isValidCPF(digits);
+    if (digits.length === 14) return isValidCNPJ(digits);
+    return false;
+}
+
+function isValidCPF(cpfDigits: string): boolean {
+    if (!cpfDigits || cpfDigits.length !== 11 || /^(\d)\1+$/.test(cpfDigits)) return false;
+
+    let sum = 0;
+    for (let i = 0; i < 9; i += 1) sum += Number(cpfDigits[i]) * (10 - i);
+    let checker = 11 - (sum % 11);
+    if (checker >= 10) checker = 0;
+    if (checker !== Number(cpfDigits[9])) return false;
+
+    sum = 0;
+    for (let i = 0; i < 10; i += 1) sum += Number(cpfDigits[i]) * (11 - i);
+    checker = 11 - (sum % 11);
+    if (checker >= 10) checker = 0;
+
+    return checker === Number(cpfDigits[10]);
+}
+
+function isValidCNPJ(cnpjDigits: string): boolean {
+    if (!cnpjDigits || cnpjDigits.length !== 14 || /^(\d)\1+$/.test(cnpjDigits)) return false;
+
+    const calcCheckDigit = (base: string, weights: number[]) => {
+        const sum = base.split('').reduce((acc, digit, idx) => acc + Number(digit) * weights[idx], 0);
+        const remainder = sum % 11;
+        return remainder < 2 ? 0 : 11 - remainder;
+    };
+
+    const firstBase = cnpjDigits.slice(0, 12);
+    const firstDigit = calcCheckDigit(firstBase, [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]);
+    if (firstDigit !== Number(cnpjDigits[12])) return false;
+
+    const secondBase = cnpjDigits.slice(0, 13);
+    const secondDigit = calcCheckDigit(secondBase, [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]);
+    return secondDigit === Number(cnpjDigits[13]);
 }
 
 export function formatPhone(value: string): string {


### PR DESCRIPTION
### Motivation
- Melhorar a qualidade de dados cadastrais evitando que CPF/CNPJ inválidos sejam salvos pela UI. 
- Tornar o fluxo de projetos mais útil ao permitir adicionar lotes diretamente a partir do card do projeto. 

### Description
- Atualiza `apps/web/src/lib/format-utils.ts` para que `formatCPF` também formate CNPJ corretamente e adiciona `isValidCpfCnpj` com validação por dígito verificador para CPF/CNPJ. 
- Altera `apps/web/src/components/panels/ProjetosPanel.tsx` para aplicar máscara automática ao campo CPF/CNPJ no modal, validar com `isValidCpfCnpj` antes de salvar e exibir mensagem de erro quando inválido. 
- Troca o comportamento do botão “Adicionar Lote” no card de projeto para selecionar o projeto e abrir o painel de lotes (antes mostrava apenas um `alert`). 
- Pequenas limpezas: corrige uso de `toast.success`, remove imports/estados não usados e ajusta imports necessários. 
- Adiciona testes unitários em `apps/web/src/lib/__tests__/format-utils.test.ts` cobrindo formatação e validação de CPF/CNPJ. 

### Testing
- Executado `npm test` dentro de `apps/web` com `vitest` e todos os testes rodando no pacote passaram (`64 tests passed`). 
- Executado `npm run build` dentro de `apps/web` e falhou devido a erros TypeScript pré-existentes em módulos não relacionados a estas mudanças (tipos/imports inconsistentes em outros arquivos), portanto build não foi concluído mas falha é fora do escopo deste PR. 
- Testes unitários adicionados: `apps/web/src/lib/__tests__/format-utils.test.ts` (passaram under `npm test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c30adecc8325af89e55845eee1b6)